### PR TITLE
Fix typographical error in arena and tournament lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,14 +223,14 @@
                             </div>
                             <div class="tab_content_list">
                             	<ul class="tab_normal">
-                                    <li><a href="#">Arena 1</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Arena 2</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Arena 3</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Arena 4</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Arena 5</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Arena 6</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Arena 7</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Arena 8</a> Curetly there are 3000 players</li>
+                                    <li><a href="#">Arena 1</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Arena 2</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Arena 3</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Arena 4</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Arena 5</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Arena 6</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Arena 7</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Arena 8</a> Currently there are 3000 players</li>
                           		</ul>
                             </div>
                           </div>
@@ -246,14 +246,14 @@
                             </div>
                             <div class="tab_content_list">
                             	<ul class="tab_normal">
-                                    <li><a href="#">Tournament 1</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Tournament 2</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Tournament 3</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Tournament 4</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Tournament 5</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Tournament 6</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Tournament 7</a> Curetly there are 3000 players</li>
-                                    <li><a href="#">Tournament 8</a> Curetly there are 3000 players</li>
+                                    <li><a href="#">Tournament 1</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Tournament 2</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Tournament 3</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Tournament 4</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Tournament 5</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Tournament 6</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Tournament 7</a> Currently there are 3000 players</li>
+                                    <li><a href="#">Tournament 8</a> Currently there are 3000 players</li>
                           		</ul>
                             </div>
                           </div>


### PR DESCRIPTION
## Summary
- fix "Curetly" typo in **index.html** popular arena and tournament sections

## Testing
- `grep -R "Curetly" -n`

------
https://chatgpt.com/codex/tasks/task_e_685c5a68cbf88327afd2f69bea47eab2